### PR TITLE
[Build] Adding basic `dockerfile` with `ubuntu` image for development

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu
+
+RUN apt-get update
+
+RUN apt-get install -y iputils-ping
+
+# ZSH and Git
+RUN apt-get -y install zsh
+RUN apt-get -y install git
+RUN apt-get -y install curl
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+
+# Neovim
+RUN curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz
+RUN rm -rf /opt/nvim
+RUN tar -C /opt -xzf nvim-linux64.tar.gz
+RUN echo 'export PATH="$PATH:/opt/nvim-linux64/bin"' >> ~/.bashrc
+RUN echo 'export PATH="$PATH:/opt/nvim-linux64/bin"' >> ~/.zshrc
+
+CMD ["ping", "google.com"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,29 @@
+Building
+-----
+
+```bash
+docker build -t docker_env --platform linux/amd64 .
+```
+
+Running
+-----
+
+```bash
+docker run -itd --platform linux/amd64 docker_env
+```
+
+Attaching
+-----
+
+```bash
+docker exec -it <container_id> /bin/bash
+```
+
+Misc
+-----
+
+* Remove all images: `docker image prune -a`
+* Remove image: `docker rm <image_id> -f`
+* Remove container: `docker rmi <container_id> -f`
+* List all images: `docker images`
+* List all containers: `docker ps`


### PR DESCRIPTION
`OSX `doesn't support thread affinity, which makes testing difficult. So to test on `OSX` we will use docker which will have all dependencies for `COS` inside (`clang`/`cmake` etc...). This is just basic version of image I will add more later on.