### PR TITLE
Milant/limit cpu count

### DIFF
--- a/os_specific.cpp
+++ b/os_specific.cpp
@@ -66,7 +66,7 @@ void bind_thread(uint64_t cpu_mask)
 
 uint32_t cpus_count()
 {
-	return std::min(MAX_CPUS, sysconf(_SC_NPROCESSORS_ONLN));
+	return std::min(MAX_CPUS, static_cast<std::uint32_t>(sysconf(_SC_NPROCESSORS_ONLN)));
 }
 
 uint64_t cpus_avail_mask()


### PR DESCRIPTION
Current implementation doesn't support more then 64 CPUs. This PR limits number of CPUs to 64.
TODO:
Windows...