### PR TITLE
Implemented basic I/O functionality (for windows OS).

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -9,9 +9,30 @@
 
 #include "worker.h"
 #include "task_manager.h"
+#include "util.h"
 
 std::random_device rd;     // only used once to initialise (seed) engine
 std::mt19937 rng(rd());    // random-number engine used (Mersenne-Twister in this case)
+
+class PRNG
+{
+public:
+	PRNG(uint64_t seed) : m_seed(seed) { }
+
+	template<typename T>
+	T rand() { return T(rand64()); }
+
+private:
+	uint64_t m_seed;
+
+	uint64_t rand64()
+	{
+		m_seed ^= m_seed >> 12, m_seed ^= m_seed << 25, m_seed ^= m_seed >> 27;
+		return m_seed * 2685821657736338717LL;
+	}
+};
+
+static PRNG prng{ 1070372 };
 
 using namespace std::chrono_literals;
 
@@ -76,6 +97,12 @@ uint64_t f3()
 	return second;
 }
 
+void thread_function()
+{
+	for (int i = 0; i < 1000; ++i)
+		task_manager.execute_task<false>(f3);
+}
+
 // Duration of ~4ms when plugged in.
 //
 uint64_t f4()
@@ -97,13 +124,7 @@ uint64_t f4()
 	return second;
 }
 
-void thread_function()
-{
-	for (int i = 0; i < 1000; ++i)
-		task_manager.execute_task<false>(f3);
-}
-
-int main(int argc, char* argv[])
+void ms3_function()
 {
 	uint64_t r = 0;
 	auto start = std::chrono::high_resolution_clock::now();
@@ -122,18 +143,70 @@ int main(int argc, char* argv[])
 
 	// std::this_thread::sleep_for(10s);
 
-	std::cout << r << "\n";
-
-	// std::vector<std::thread> v;
-	// 
-	// for (int i = 0; i < 10; ++i)
-	// 	v.push_back(std::thread{ thread_function });
-	// 
-	// for (auto& it : v)
-	// 	it.join();
-
-	// std::this_thread::sleep_for(5s);
-	// e.signal();
-
-	// std::cout << f3() << "\n";
+	// std::cout << r << "\n";
 }
+
+void test_signal()
+{
+	std::vector<std::thread> v;
+	
+	for (int i = 0; i < 10; ++i)
+		v.push_back(std::thread{ thread_function });
+	
+	for (auto& it : v)
+		it.join();
+
+	std::this_thread::sleep_for(5s);
+	e.signal();
+
+	std::cout << f3() << "\n";
+}
+
+#if defined _WIN32
+
+// HANDLE file_for_write = CreateFile("io_testing_file_0", GENERIC_WRITE, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED | FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH, NULL);
+HANDLE file_for_read = CreateFile("io_testing_file_0", GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED | FILE_FLAG_NO_BUFFERING, NULL);
+
+void read_from_file()
+{
+	constexpr int read_size = 8 * 1024;
+	int max_read_size = read_size * 128;
+
+	auto buf = std::make_unique<char[]>(read_size);
+
+	read_file(file_for_read, buf.get(), read_size, (prng.rand<uint64_t>() % read_size) * read_size);
+	std::cout << "Read buffer: " << buf.get() << "\n";
+}
+
+//void write_to_file()
+//{
+//	int write_size = 8 * 1024;
+//	int max_file_size = write_size * 128;
+//
+//	std::string io_str(write_size, 'a');
+//	
+//	// for (int i = 0; i < 10; ++i)
+//	// 	std::cout << prng.rand<uint64_t>() << "\n";
+//
+//	write_file(file_for_write, io_str.data(), io_str.size(), (prng.rand<uint64_t>() % max_file_size) * io_str.size());
+//}
+
+int main(int argc, char* argv[])
+{
+	/*for (int i = 0; i < 128; ++i)
+		task_manager.execute_task<true>(write_to_file);*/
+
+		// task_manager.execute_task<true>(io_func);
+
+	for (int i = 0; i < 128; ++i)
+		task_manager.execute_task<true>(read_from_file);
+}
+
+#else
+
+int main(int argc, char* argv[])
+{
+	
+}
+
+#endif

--- a/os_specific.cpp
+++ b/os_specific.cpp
@@ -1,8 +1,10 @@
 #include <cstdint>
 #include <iostream>
 #include <cassert>
+#include <exception>
 
 #include "os_specific.h"
+#include "util.h"
 
 // OS specific preprocessor definitions.
 //
@@ -28,6 +30,13 @@ constexpr uint32_t MAX_CPUS = 64;
 //
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+
+// Helper function for getting result from win32 API.
+//
+DWORD bool_to_error(bool b)
+{
+	return b ? ERROR_SUCCESS : GetLastError();
+}
 
 // Returns number of CPUs in the system.
 //
@@ -56,6 +65,83 @@ uint64_t cpus_avail_mask()
 void bind_thread(uint64_t cpu_mask)
 {
 	SetThreadAffinityMask(GetCurrentThread(), cpu_mask);
+}
+
+OVERLAPPED* to_ol_ptr(IO_Control& io_ctrl)
+{
+	return reinterpret_cast<OVERLAPPED*>(&io_ctrl.m_ol);
+}
+
+void read_file(IO_Request& io)
+{
+	DWORD read_res = bool_to_error(ReadFile(io.m_file_handle, io.m_buffer, DWORD(io.m_nbytes), nullptr, to_ol_ptr(io.m_control)));
+
+	// std::cout << "ReadFile: " << read_res << "\n";
+
+	switch (read_res)
+	{
+	case (ERROR_SUCCESS):
+		io.m_state = IO_Request::State::completed;
+		break;
+	case (ERROR_IO_PENDING):
+		io.m_state = IO_Request::State::pending;
+		break;
+	default:
+		io.m_state = IO_Request::State::error;
+		break;
+	}
+}
+
+void write_file(IO_Request& io)
+{
+	DWORD write_res = bool_to_error(WriteFile(io.m_file_handle, io.m_buffer, DWORD(io.m_nbytes), nullptr, to_ol_ptr(io.m_control)));
+
+	// std::cout << "WriteFile: " << write_res << "\n";
+
+	switch (write_res)
+	{
+	case (ERROR_SUCCESS):
+		io.m_state = IO_Request::State::completed;
+		break;
+	case (ERROR_IO_PENDING):
+		io.m_state = IO_Request::State::pending;
+		break;
+	default:
+		io.m_state = IO_Request::State::error;
+		break;
+	}
+}
+
+bool io_completed(IO_Control& io_control)
+{
+	return HasOverlappedIoCompleted(to_ol_ptr(io_control));
+}
+
+void update_io_state(IO_Request& io)
+{
+	if (io.pending() && !io_completed(io.m_control))
+	{
+		// std::cout << "IO still pending...\n";
+		return;
+	}
+
+	DWORD bytes = 0;
+	DWORD ol_res = bool_to_error(GetOverlappedResult(io.m_file_handle, to_ol_ptr(io.m_control), &bytes, false));
+
+	// std::cout << "GetOverlappedResult: " << ol_res << ", Bytes written : " << bytes << "\n";
+
+	switch (ol_res)
+	{
+	case (ERROR_SUCCESS):
+		io.m_state = IO_Request::State::completed;
+		break;
+	case (ERROR_IO_PENDING):
+		io.m_state = IO_Request::State::pending;
+		break;
+	default:
+		io.m_state = IO_Request::State::error;
+		break;
+	}
 }
 
 #elif defined(OS_LINUX)
@@ -136,6 +222,11 @@ void print_thread_affinity()
 	std::cout << ENDL;
 }
 
+void read_file(IO_Request& io) { throw std::logic_error{ "Not implemented" }; }
+void write_file(IO_Request& io) { throw std::logic_error{ "Not implemented" }; }
+bool io_completed(IO_Control& io_control) { throw std::logic_error{ "Not implemented" }; }
+void update_io_state(IO_Request& io) { throw std::logic_error{ "Not implemented" }; }
+
 #elif defined(OS_MAC)
 #include <sys/sysctl.h>
 
@@ -178,6 +269,11 @@ void bind_thread(uint64_t cpu_mask)
 {
     return;
 }
+
+void read_file(IO_Request& io) { throw std::logic_error{ "Not implemented" }; }
+void write_file(IO_Request& io) { throw std::logic_error{ "Not implemented" }; }
+bool io_completed(IO_Control& io_control) { throw std::logic_error{ "Not implemented" }; }
+void update_io_state(IO_Request& io) { throw std::logic_error{ "Not implemented" }; }
 
 #else
 static_assert(!"Unknown OS.");

--- a/os_specific.h
+++ b/os_specific.h
@@ -5,9 +5,44 @@
 
 #include <cstdint>
 
+class IO_Request;
+
+struct Overlapped final
+{
+    unsigned long long m_internal, m_internal_high;
+    union
+    {
+        struct { unsigned long m_offset, m_offset_high; };
+        void* m_ptr;
+    };
+
+    void* m_event;
+};
+
+struct IO_Control final
+{
+public:
+	IO_Control(uint64_t offset) : m_ol{}
+	{
+		m_ol.m_offset = offset & 0xFFFFFFFF;
+		m_ol.m_offset_high = (offset >> 32) & 0xFFFFFFFF;
+	}
+
+    Overlapped m_ol;
+};
+
+// CPU and thread related functions.
+//
 uint32_t cpus_count(); // maybe just std::thread::hardware_concurrency?
 uint64_t cpus_avail_mask();
 void bind_thread(uint64_t cpu_mask);
 void print_thread_affinity();
+
+// I/O functions.
+//
+void read_file(IO_Request& io);
+void write_file(IO_Request& io);
+bool io_completed(IO_Control& io_control);
+void update_io_state(IO_Request& io);
 
 #endif // OS_SPECIFIC_H

--- a/scheduler.cpp
+++ b/scheduler.cpp
@@ -1,7 +1,10 @@
+#include <iostream>
+
 #include "scheduler.h"
 #include "cpu.h"
 #include "config.h"
 #include "task_manager.h"
+#include "util.h"
 
 Scheduler::Scheduler(const CPU& cpu)
 	: m_cpu{ cpu }
@@ -19,9 +22,15 @@ Scheduler::Scheduler(const CPU& cpu)
 	m_worker->m_cv.notify_one();
 }
 
+Scheduler::~Scheduler()
+{
+	set_state(Scheduler::State::exiting);
+}
+
 bool Scheduler::has_idle_workers() const { return !m_idle_queue.empty(); }
 bool Scheduler::has_runnable_workers() const { return !m_runnable_queue.empty(); }
 bool Scheduler::has_waiting_workers() const { return !m_waiting_queue.empty(); }
+bool Scheduler::has_pending_io_workers() const { return !m_pending_io_queue.empty(); }
 
 void Scheduler::save_runnable(Worker* worker)
 {
@@ -44,6 +53,12 @@ void Scheduler::save_waiting(Worker* worker)
 {
 	m_waiting_queue.push_back(worker);
 	worker->set_state(Worker::State::waiting);
+}
+
+void Scheduler::save_pending_io(Worker* worker)
+{
+	m_pending_io_queue.push_back(worker);
+	worker->set_state(Worker::State::pending_io);
 }
 
 void Scheduler::prepare_next_worker()
@@ -81,8 +96,27 @@ void Scheduler::schedule_idle_worker()
 	m_idle_queue.pop_front();
 
 	worker->m_task = next_task();
-	worker->set_state(Worker::State::runnable);
-	m_runnable_queue.push_back(worker);
+	save_runnable(worker);
+}
+
+// Moves workers from pending_io to runnable queue if worker's I/O is completed.
+//
+void Scheduler::schedule_io_workers()
+{
+	auto io_completed = [](Worker* worker)
+	{
+		worker->m_io_request->update();
+		return worker->m_io_request->completed();
+	};
+
+	auto begin = m_pending_io_queue.begin();
+	auto end = m_pending_io_queue.end();
+
+	for (auto it = std::find_if(begin, end, io_completed); it != end; it = std::find_if(it, end, io_completed))
+	{
+		save_runnable(*it);
+		it = m_pending_io_queue.erase(it);
+	}
 }
 
 void Scheduler::schedule_idle_workers()
@@ -95,36 +129,35 @@ void Scheduler::schedule_idle_workers()
 //
 void Scheduler::schedule_waiting_workers()
 {
-	auto it = m_waiting_queue.begin();
-	while (it != m_waiting_queue.end())
-	{
-		Worker* worker = *it;
+	auto signaled = [](Worker* worker) { return worker->m_event->m_cond.load(); };
 
-		if (worker->m_event->m_cond)
-		{
-			m_waiting_queue.erase(it++);
-			worker->m_event = nullptr;
-			worker->set_state(Worker::State::runnable);
-			m_runnable_queue.push_back(worker);
-		}
-		else
-			++it;
+	auto begin = m_waiting_queue.begin();
+	auto end = m_waiting_queue.end();
+
+	for (auto it = std::find_if(begin, end, signaled); it != end; it = std::find_if(it, end, signaled))
+	{
+		save_runnable(*it);
+		it = m_waiting_queue.erase(it);
 	}
 }
 
 void Scheduler::schedule_workers()
 {
+	schedule_io_workers();
 	schedule_waiting_workers();
 	schedule_idle_workers();
+}
+
+void Scheduler::schedule()
+{
+	schedule_workers();
 
 	// Idle loop if there is no work.
 	//
 	while (!has_runnable_workers() && !should_exit())
 	{
 		idle_sleep();
-
-		schedule_waiting_workers();
-		schedule_idle_workers();
+		schedule_workers();
 	}
 
 	if (should_exit())
@@ -135,6 +168,8 @@ void Scheduler::schedule_workers()
 
 void Scheduler::idle_sleep()
 {
+	// std::cout << "Idle sleep.\n";
+
 	// TODO: Check what should be done here.
 	// TODO: Release CPU (sleep) only when our time slice expires.
 	// TODO: Check why there is a problem with sync tasks execution
@@ -222,6 +257,14 @@ bool Scheduler::sync_yield(Worker* worker)
 	return true; // proceed with scheduling.
 }
 
+// Synchronization point for the workers for I/O operations.
+//
+bool Scheduler::sync_io(Worker* worker)
+{
+	save_pending_io(worker);
+	return true; // proceed with scheduling.
+}
+
 // Synchronization point for the workers in main worker loop.
 //
 bool Scheduler::sync_main(Worker* worker)
@@ -257,6 +300,7 @@ constexpr auto sync_func()
 	if      constexpr (ctx == SyncCtx::main)       return &Scheduler::sync_main;
 	else if constexpr (ctx == SyncCtx::yield)      return &Scheduler::sync_yield;
 	else if constexpr (ctx == SyncCtx::wait_event) return &Scheduler::sync_wait_event;
+	else if constexpr (ctx == SyncCtx::io)         return &Scheduler::sync_io;
 }
 
 // Synchronization point for the workers.
@@ -268,7 +312,7 @@ void Scheduler::sync(Worker* worker)
 {
 	if ((this->*sync_func<ctx>())(worker))
 	{
-		schedule_workers();
+		schedule();
 
 		if (m_worker != worker)
 			context_switch(worker);
@@ -286,9 +330,10 @@ void Scheduler::exit_workers() const
 
 bool Scheduler::should_exit()
 {
-	return exiting() && !has_runnable_workers() && !has_waiting_workers() && !has_tasks();
+	return exiting() && !has_runnable_workers() && !has_waiting_workers() && !has_pending_io_workers() && !has_tasks();
 }
 
 template void Scheduler::sync<SyncCtx::main>(Worker* worker);
 template void Scheduler::sync<SyncCtx::yield>(Worker* worker);
 template void Scheduler::sync<SyncCtx::wait_event>(Worker* worker);
+template void Scheduler::sync<SyncCtx::io>(Worker* worker);

--- a/scheduler.h
+++ b/scheduler.h
@@ -8,6 +8,7 @@
 #include <deque>
 #include <list>
 #include <mutex>
+#include <atomic>
 
 #include "worker.h" // This can be moved and class Worker can be forward declared if we dispose Worker::State.
 #include "task_manager.h"
@@ -17,7 +18,7 @@ class CPU;
 
 // Synchronization context for scheduler.
 //
-enum class SyncCtx : int { main, yield, wait_event };
+enum class SyncCtx : int { main, yield, wait_event, io };
 
 class Scheduler final
 {
@@ -25,13 +26,16 @@ public:
 	enum class State : int { initializing, running, exiting };
 
 	Scheduler(const CPU& cpu);
+	~Scheduler();
 
 	bool has_idle_workers() const;
 	bool has_runnable_workers() const;
 	bool has_waiting_workers() const;
+	bool has_pending_io_workers() const;
 
 	void save_runnable(Worker* worker);
 	void save_waiting(Worker* worker);
+	void save_pending_io(Worker* worker);
 
 	template<bool back>
 	void save_idle(Worker* worker);
@@ -44,10 +48,12 @@ public:
 
 	void schedule_idle_worker();
 
+	void schedule_io_workers();
 	void schedule_idle_workers();
 	void schedule_waiting_workers();
-
 	void schedule_workers();
+
+	void schedule();
 
 	void idle_sleep();
 
@@ -67,24 +73,27 @@ public:
 	bool sync_main(Worker* worker);
 	bool sync_yield(Worker* worker);
 	bool sync_wait_event(Worker* worker);
+	bool sync_io(Worker* worker);
 
 	template<SyncCtx ctx>
 	void sync(Worker* worker);
 
 	void exit_workers() const;
-	bool should_exit() ;
+	bool should_exit();
 
 public:
 	const CPU& m_cpu;
 
 	Worker* m_worker;
-	std::mutex m_workers_mtx;
 	std::deque<Worker*> m_runnable_queue;
 	std::deque<Worker*> m_idle_queue;
 	std::list<Worker*> m_waiting_queue;
+	std::list<Worker*> m_pending_io_queue;
+
+	std::mutex m_workers_mtx;
 	std::mutex m_tasks_mtx;
 	std::deque<std::shared_ptr<Task>> m_tasks;
-	State m_state;
+	std::atomic<State> m_state;
 	bool m_workers_started;
 	uint64_t m_load;
 

--- a/util.cpp
+++ b/util.cpp
@@ -1,0 +1,35 @@
+#include <cstdint>
+
+#include "util.h"
+#include "worker.h"
+#include "os_specific.h"
+
+IO_Request::IO_Request(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset, Type type)
+	: m_file_handle{ file_handle }
+	, m_buffer{ buffer }
+	, m_nbytes{ nbytes }
+	, m_offset{ offset }
+	, m_control{ offset }
+	, m_type{ type }
+	, m_state{ State::init }
+{
+	if (m_type == Type::read)
+		read_file(*this);
+	else
+		write_file(*this);
+}
+
+void IO_Request::update()
+{
+	update_io_state(*this);
+}
+
+void read_file(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset)
+{
+	tls_worker->read_file(file_handle, buffer, nbytes, offset);
+}
+
+void write_file(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset)
+{
+	tls_worker->write_file(file_handle, buffer, nbytes, offset);
+}

--- a/util.h
+++ b/util.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#ifndef COS_UTIL_H
+#define COS_UTIL_H
+
+#include <cstdint>
+
+#include "os_specific.h"
+
+class IO_Request final
+{
+public:
+	enum class Type : int { read, write };
+	enum class State : int { init, error, pending, completed };
+
+	IO_Request(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset, Type type);
+
+	bool completed() const { return m_state == State::completed; }
+	bool pending() const { return m_state == State::pending; }
+	bool error() const { return m_state == State::error; }
+	void update();
+
+	void* m_file_handle;
+	void* m_buffer;
+	uint64_t m_nbytes;
+	uint64_t m_offset;
+	IO_Control m_control;
+	Type m_type;
+	State m_state;
+};
+
+void read_file(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset);
+void write_file(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset);
+
+#endif // COS_UTIL_H

--- a/worker.cpp
+++ b/worker.cpp
@@ -4,6 +4,7 @@
 #include "cpu.h"
 #include "os_specific.h"
 #include "scheduler.h"
+#include "util.h"
 
 Event::Event() : m_cond{ false } {};
 void Event::signal() { m_cond = true; }
@@ -25,8 +26,6 @@ Worker::Worker(uint64_t id, Scheduler& scheduler)
 
 Worker::~Worker()
 {
-	m_scheduler.set_state(Scheduler::State::exiting);
-
 	if (m_thread.joinable())
 		m_thread.join();
 }
@@ -37,7 +36,7 @@ void Worker::set_state(Worker::State state)
 	m_state = state;
 }
 
-bool Worker::state_idle(State state) { return state == State::idle || state == State::waiting; }
+bool Worker::state_idle(State state) { return state == State::idle || state == State::waiting || state == State::pending_io; }
 bool Worker::state_runnable(State state) { return state == State::runnable || state == State::running; }
 
 bool Worker::exit() const
@@ -61,6 +60,22 @@ void Worker::wait_event(Event& event)
 		m_event = &event;
 		m_scheduler.sync<SyncCtx::wait_event>(this);
 	}
+}
+
+void Worker::read_file(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset)
+{
+	m_io_request = std::make_unique<IO_Request>(file_handle, buffer, nbytes, offset, IO_Request::Type::read);
+
+	if (m_io_request->m_state == IO_Request::State::pending)
+		m_scheduler.sync<SyncCtx::io>(this);
+}
+
+void Worker::write_file(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset)
+{
+	m_io_request = std::make_unique<IO_Request>(file_handle, buffer, nbytes, offset, IO_Request::Type::write);
+
+	if (m_io_request->m_state == IO_Request::State::pending)
+		m_scheduler.sync<SyncCtx::io>(this);
 }
 
 void Worker::notify()
@@ -106,7 +121,7 @@ void Worker::main_loop()
 			std::cout << ex.what() << "\n";
 		}
 
-		// std::cout << "CPU " << m_cpu.m_id << ": worker id " << id() << " task done.\n";
+		// std::cout << "CPU " << m_scheduler.m_cpu.m_id << ": worker id " << id() << " task done.\n";
 
 		m_task->notify();
 		m_task.reset();

--- a/worker.h
+++ b/worker.h
@@ -10,6 +10,7 @@
 #include <atomic>
 
 #include "task_manager.h"
+#include "os_specific.h"
 
 class Scheduler;
 
@@ -30,7 +31,7 @@ public:
 class Worker final
 {
 public:
-	enum class State : int { initializing, idle, waiting, runnable, running, exiting };
+	enum class State : int { initializing, idle, waiting, pending_io, runnable, running, exiting };
 
 	static bool state_idle(State state);
 	static bool state_runnable(State state);
@@ -52,6 +53,8 @@ public:
 
 	void yield();
 	void wait_event(Event& event);
+	void read_file(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset);
+	void write_file(void* file_handle, void* buffer, uint64_t nbytes, uint64_t offset);
 
 	void set_state(State state);
 
@@ -74,6 +77,7 @@ public:
 
 	Event* m_event;
 	std::shared_ptr<Task> m_task;
+	std::unique_ptr<IO_Request> m_io_request;
 	Scheduler& m_scheduler;
 	std::thread m_thread;
 };


### PR DESCRIPTION
Implemented basic I/O functionality (for windows OS).

This implementation assumes async I/O capabilities on the OS level.

When I/O is issued, it calls one of async I/O functions, and worker will be blocked until I/O request is done. It will park itself in the io_pending queue. Every time we are entering scheduler, we will check whether I/O request is completed and move worker to runnable queue if it is. So, from user perspective I/O request will be executed synchronously since worker is blocked, but we are executing asynchronous I/O on the OS level.

For the next improvements, we should provide async I/O functionality from the user perspective and also support async I/O on OSs that do not support async I/O calls.