### PR TITLE
Fixing build

### DIFF
--- a/scheduler.cpp
+++ b/scheduler.cpp
@@ -258,6 +258,8 @@ private:
 
 static constexpr Scheduler_Loads Loads;
 
+static_assert(Loads[Worker::State::runnable] == 10);
+
 // Sets new scheduler load based on previous and new worker state.
 //
 void Scheduler::manage_load(Worker::State prev_state, Worker::State new_state)


### PR DESCRIPTION
Got this error msg on clang and gcc.

```
/Users/mtopalovic/Desktop/src/cos_scheduler/scheduler.cpp:259:34: error: constexpr variable 'Loads' must be initialized by a constant expression
static constexpr Scheduler_Loads Loads {};
                                 ^~~~~~~~
/Users/mtopalovic/Desktop/src/cos_scheduler/scheduler.cpp:259:34: note: subobject of type 'int' is not initialized
/Users/mtopalovic/Desktop/src/cos_scheduler/scheduler.cpp:256:6: note: subobject declared here
        int m_loads[int(Worker::State::exiting) + 1];
```